### PR TITLE
updating to 0.13.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
-{% set version = "0.12.2" %}
+{% set version = "0.13.0" %}
 
 package:
   name: invoke
   version: {{ version }}
 
-source:  
+source:
   fn: invoke-{{ version }}.tar.gz
-  url: https://pypi.python.org/packages/source/i/invoke/invoke-{{ version }}.tar.gz
-  md5: f46192ea664325464a02f1c7f735e3cb
+  url: https://pypi.io/packages/source/i/invoke/invoke-{{ version }}.tar.gz
+  sha256: 1a1992fac5292b97448d1c85dc0793e309c4c376acbc39ff067056d71fdc241d
 
 build:
   number: 0


### PR DESCRIPTION
Updating to 0.13.0
- using pypi.io
- using sha256

Would love to get the tests running at some point! unsurprisingly, it uses [invocations](https://github.com/pyinvoke/invocations), but that's probably worth having as a feedstock anyway!
